### PR TITLE
feat(core): add range prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,31 @@
 ## Navigation 🗺️ :
 
 - [@lls/react-light-calendar](#llsreact-light-calendar)
-  - [Navigation 🗺️ :](#Navigation-️-)
-  - [Why 🤔](#Why-)
-  - [How to use ✍️](#How-to-use-️)
-  - [Demo 👀](#Demo-)
-  - [Compatibility ✅](#Compatibility-)
+  - [Navigation 🗺️ :](#navigation-️-)
+  - [Why 🤔](#why-)
+  - [How to use ✍️](#how-to-use-️)
+  - [Demo 👀](#demo-)
+  - [Compatibility ✅](#compatibility-)
     - [react / react-dom](#react--react-dom)
-    - [Browsers 🌍](#Browsers-)
-  - [Changelog 🗒️](#Changelog-️)
-  - [Examples 📋](#Examples-)
-    - [Basic example](#Basic-example)
-    - [Good practice example](#Good-practice-example)
-    - [Input example](#Input-example)
-  - [API 📖](#API-)
-    - [startDate](#startDate)
-    - [endDate](#endDate)
-    - [onChange](#onChange)
-    - [disableDates](#disableDates)
-    - [displayTime](#displayTime)
-    - [dayLabels](#dayLabels)
-    - [monthLabels](#monthLabels)
+    - [Browsers 🌍](#browsers-)
+  - [Changelog 🗒️](#changelog-️)
+  - [Examples 📋](#examples-)
+    - [Basic example](#basic-example)
+    - [Good practice example](#good-practice-example)
+    - [Input example](#input-example)
+  - [API 📖](#api-)
+    - [startDate](#startdate)
+    - [endDate](#enddate)
+    - [onChange](#onchange)
+    - [disableDates](#disabledates)
+    - [displayTime](#displaytime)
+    - [dayLabels](#daylabels)
+    - [monthLabels](#monthlabels)
     - [timezone](#timezone)
-  - [Development 💻](#Development-)
-  - [License 🖋](#License-)
+    - [markedDays](#markeddays)
+    - [range](#range)
+  - [Development 💻](#development-)
+  - [License 🖋](#license-)
 
 <!-- /TOC -->
 
@@ -121,6 +123,7 @@ import '@lls/react-light-calendar/dist/index.css' // Default Style
 
 ## Changelog 🗒️
 
+* `2.3.0` : Add `range` prop (https://github.com/lelivrescolaire/react-light-calendar/issues/15)
 * `2.2.0` : Only show useful days (https://github.com/lelivrescolaire/react-light-calendar/issues/10)
 * `2.0.6` : Fix month/year navigation (https://github.com/lelivrescolaire/react-light-calendar/issues/6)
 
@@ -291,6 +294,16 @@ const tmr = today + (24*60*60*1000)
 
 <Calendar markedDays={[today, tmr]} />
 ```
+
+---------------------------------------
+
+### range
+* Type : *Boolean*
+* Default value : `true`
+* Required : *false*
+* Available since : *v2.3.0*
+
+If `false` select a single date.
 
 ---------------------------------------
 

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -24,14 +24,15 @@ class Calendar extends Component {
       this.setState(this.getInitialState(this.props))
   }
 
-  getInitialState = ({ startDate, endDate }) => ({
+  getInitialState = ({ startDate, endDate, range }) => ({
     ...initMonth(startDate),
-    ...parseRange(startDate, endDate)
+    ...parseRange(startDate, range ? endDate  : null)
   })
 
   onClickDay = day => {
     const { startDate, endDate } = this.state
-    if (!startDate) this.update({ startDate: day })
+    const { range } = this.props
+    if (!startDate || !range) this.update({ startDate: day })
     else if (startDate && !endDate) this.update(parseRange(startDate, day))
     else this.update({ startDate: day, endDate: null })
   }
@@ -139,7 +140,8 @@ Calendar.defaultProps = {
   monthLabels: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
   timezone: 'UTC',
   markedDays: () => false,
-  onClickDate: () => {}
+  onClickDate: () => {},
+  range: true
 }
 
 Calendar.propTypes = {
@@ -152,7 +154,8 @@ Calendar.propTypes = {
   monthLabels: arrayOf(string),
   timezone: string,
   markedDays: oneOfType([arrayOf(number), func]),
-  onClickDate: func
+  onClickDate: func,
+  range: bool
 }
 
 export default Calendar

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { bool } from 'prop-types'
 import t from 'timestamp-utils'
 import { storiesOf } from '@storybook/react'
 import Calendar from '../src/index'
@@ -17,7 +18,7 @@ class OnChange extends Component {
     const startDate = date.getTime()
     this.state = {
       startDate,
-      endDate: new Date(startDate).setDate(date.getDate() + 6)
+      endDate: props.range ? new Date(startDate).setDate(date.getDate() + 6) : null
     }
   }
 
@@ -32,12 +33,20 @@ class OnChange extends Component {
 
     return (
       <div>
-        <Calendar startDate={startDate} endDate={endDate} onChange={this.onChange} displayTime />
+        <Calendar startDate={startDate} endDate={endDate} onChange={this.onChange} displayTime range={this.props.range} />
         <div key='start-date'>START DATE : {startDate && sDate}</div>
         <div key='end-date'>END DATE : {endDate && eDate}</div>
       </div>
     )
   }
+}
+
+OnChange.defaultProps = {
+  range: true
+}
+
+OnChange.propTypes = {
+  range: bool
 }
 
 const InputCSS = () =>
@@ -122,6 +131,7 @@ class MarkedDays extends Component{
 storiesOf('Calendar', module)
   .add('default', () => <Calendar />)
   .add('onChange', () => <OnChange />)
+  .add('onChange (no range)', () => <OnChange range={false} />)
   .add('default value', () => <Calendar startDate={718585200000} />)
   .add('default values', () => <DefaultValues />)
   .add('with time', () => <Calendar startDate={new Date().getTime()} displayTime />)


### PR DESCRIPTION
https://github.com/lelivrescolaire/react-light-calendar/issues/15 Add `range` input 

* Type : *Boolean*
* Default value : `true`
* Required : *false*
* Available since : *v2.3.0*

If `false` select a single date.