### PR TITLE
chore(dependencies): update timestamp-utils@2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "lodash.times": "4.3.2",
     "prop-types": "15.7.2",
-    "timestamp-utils": "2.1.0"
+    "timestamp-utils": "2.2.0"
   },
   "devDependencies": {
     "@babel/core": "7.5.5",


### PR DESCRIPTION
Should fix the date parsing error of https://github.com/lelivrescolaire/react-light-calendar/issues/17.
Close #17